### PR TITLE
Update ft-ops.cc

### DIFF
--- a/ft/ft-ops.cc
+++ b/ft/ft-ops.cc
@@ -224,7 +224,7 @@ basement nodes, bulk fetch,  and partial fetch:
 #include <util/sort.h>
 
 #include <stdint.h>
-static TOKULOGGER global_logger = nullptr;
+TOKULOGGER global_logger = nullptr;
 static const uint32_t this_version = FT_LAYOUT_VERSION;
 
 /* Status is intended for display to humans to help understand system behavior.


### PR DESCRIPTION
Remove `static` from `global_logger` definition to fix link errors.

Trying to insmod `ftfs.ko` would fail with an "Unknown symbol in module" error because `global_logger` was declared as `extern` in other `.cc` files, but since it was declared as `static` it's only accessible from within the same file.