### PR TITLE
Fix CI for 3.11 kernel

### DIFF
--- a/Jenkinsfiles/Linux-xfs
+++ b/Jenkinsfiles/Linux-xfs
@@ -10,7 +10,7 @@ pipeline {
   stages {
     stage('Testing') {
       steps {
-	timeout(time: 15, unit: 'MINUTES') {
+	timeout(time: 20, unit: 'MINUTES') {
            sh '''
 	     /usr/bin/sudo /bin/cp /host/playpen/btrfs/* /sbin/
 	     /usr/bin/sudo /bin/ln -s $(/bin/pwd) /oscar/betrfs

--- a/Jenkinsfiles/build-bench.sh
+++ b/Jenkinsfiles/build-bench.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-vagrant ssh -c "set -e; cd /oscar/betrfs; wget https://auku.cs.unc.edu/depot/linux-source-3.11.10-ftfs_20180618.00_all.deb; sudo dpkg -i linux-source-3.11.10-ftfs_20180618.00_all.deb; tar -xf /usr/src/linux-source-3.11.10-ftfs.tar.bz2; mv linux-source-3.11.10-ftfs linux-3.11.10; cd linux-3.11.10; cp ../qemu-utils/jenkins.config.3.11.10 .config; make oldconfig; cd ..; mkdir -p build; cp qemu-utils/cmake-ft.sh build/; cd build; sed -i 's/DEBUG/RELEASE/g' cmake-ft.sh; ./cmake-ft.sh; cd ../filesystem; make"
+vagrant ssh -c "set -e; cd /oscar/betrfs; wget https://auku.cs.unc.edu/depot/linux-source-3.11.10-ftfs_20180618.00_all.deb; sudo dpkg -i linux-source-3.11.10-ftfs_20180618.00_all.deb; tar -xf /usr/src/linux-source-3.11.10-ftfs.tar.bz2; mv linux-source-3.11.10-ftfs linux-3.11.10; cd linux-3.11.10; cp ../qemu-utils/jenkins.config.3.11.10 .config; make oldconfig; make -j 4; cd ..; mkdir -p build; cp qemu-utils/cmake-ft.sh build/; cd build; sed -i 's/DEBUG/RELEASE/g' cmake-ft.sh; ./cmake-ft.sh; cd ../filesystem; make"
 result=$?
 
 exit ${result}

--- a/Jenkinsfiles/build-bench.sh
+++ b/Jenkinsfiles/build-bench.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-vagrant ssh -c "set -e; cd /oscar/betrfs; wget https://auku.cs.unc.edu/depot/linux-source-3.11.10-ftfs_20180618.00_all.deb; sudo dpkg -i linux-source-3.11.10-ftfs_20180618.00_all.deb; tar -xf /usr/src/linux-source-3.11.10-ftfs.tar.bz2; mv linux-source-3.11.10-ftfs linux-3.11.10; cd linux-3.11.10; cp ../qemu-utils/jenkins.config.3.11.10 .config; make oldconfig; cd ..; mkdir -p build; cp qemu-utils/cmake-ft.sh build/; cd build; sed -i 's/DEBUG/RELEASE/g' cmake-ft.sh; ./cmake-ft.sh; cd filesystem; make"
+vagrant ssh -c "set -e; cd /oscar/betrfs; wget https://auku.cs.unc.edu/depot/linux-source-3.11.10-ftfs_20180618.00_all.deb; sudo dpkg -i linux-source-3.11.10-ftfs_20180618.00_all.deb; tar -xf /usr/src/linux-source-3.11.10-ftfs.tar.bz2; mv linux-source-3.11.10-ftfs linux-3.11.10; cd linux-3.11.10; cp ../qemu-utils/jenkins.config.3.11.10 .config; make oldconfig; cd ..; mkdir -p build; cp qemu-utils/cmake-ft.sh build/; cd build; sed -i 's/DEBUG/RELEASE/g' cmake-ft.sh; ./cmake-ft.sh; cd ../filesystem; make"
 result=$?
 
 exit ${result}

--- a/Jenkinsfiles/build-bench.sh
+++ b/Jenkinsfiles/build-bench.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-vagrant ssh -c "set -e; cd /oscar/betrfs; wget https://auku.cs.unc.edu/depot/linux-source-3.11.10-ftfs_20180618.00_all.deb; sudo dpkg -i linux-source-3.11.10-ftfs_20180618.00_all.deb; mkdir -p build; cp qemu-utils/cmake-ft.sh build/; cd build; sed -i 's/DEBUG/RELEASE/g' cmake-ft.sh; ./cmake-ft.sh; cd ../filesystem; make"
+vagrant ssh -c "set -e; cd /oscar/betrfs; mkdir -p build; cp qemu-utils/cmake-ft.sh build/; cd build; sed -i 's/DEBUG/RELEASE/g' cmake-ft.sh; ./cmake-ft.sh; cd ../filesystem; make"
 result=$?
 
 exit ${result}

--- a/Jenkinsfiles/build-bench.sh
+++ b/Jenkinsfiles/build-bench.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-vagrant ssh -c "set -e; cd /oscar/betrfs; wget https://auku.cs.unc.edu/depot/linux-source-3.11.10-ftfs_20180618.00_all.deb; sudo dpkg -i linux-source-3.11.10-ftfs_20180618.00_all.deb; tar -xf /usr/src/linux-source-3.11.10-ftfs.tar.bz2; mv linux-source-3.11.10-ftfs linux-3.11.10; mkdir -p build; cp qemu-utils/cmake-ft.sh build/; cd build; sed -i 's/DEBUG/RELEASE/g' cmake-ft.sh; ./cmake-ft.sh; cd ../filesystem; make"
+vagrant ssh -c "set -e; cd /oscar/betrfs; wget https://auku.cs.unc.edu/depot/linux-source-3.11.10-ftfs_20180618.00_all.deb; sudo dpkg -i linux-source-3.11.10-ftfs_20180618.00_all.deb; tar -xf /usr/src/linux-source-3.11.10-ftfs.tar.bz2; mv linux-source-3.11.10-ftfs linux-3.11.10; cd linux-3.11.10; cp ../qemu-utils/jenkins.config.3.11.10 .config; make oldconfig; mkdir -p build; cp qemu-utils/cmake-ft.sh build/; cd build; sed -i 's/DEBUG/RELEASE/g' cmake-ft.sh; ./cmake-ft.sh; cd ../filesystem; make"
 result=$?
 
 exit ${result}

--- a/Jenkinsfiles/build-bench.sh
+++ b/Jenkinsfiles/build-bench.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-vagrant ssh -c "set -e; cd /oscar/betrfs; wget https://auku.cs.unc.edu/depot/linux-source-3.11.10-ftfs_20180618.00_all.deb; sudo dpkg -i linux-source-3.11.10-ftfs_20180618.00_all.deb; tar -xf /usr/src/linux-source-3.11.10-ftfs.tar.bz2; mv linux-source-3.11.10-ftfs linux-3.11.10; cd linux-3.11.10; cp ../qemu-utils/jenkins.config.3.11.10 .config; make oldconfig; make -j 4; cd ..; mkdir -p build; cp qemu-utils/cmake-ft.sh build/; cd build; sed -i 's/DEBUG/RELEASE/g' cmake-ft.sh; ./cmake-ft.sh; cd ../filesystem; make"
+vagrant ssh -c "set -e; cd /oscar/betrfs; wget https://auku.cs.unc.edu/depot/linux-source-3.11.10-ftfs_20180618.00_all.deb; sudo dpkg -i linux-source-3.11.10-ftfs_20180618.00_all.deb; mkdir -p build; cp qemu-utils/cmake-ft.sh build/; cd build; sed -i 's/DEBUG/RELEASE/g' cmake-ft.sh; ./cmake-ft.sh; cd ../filesystem; make"
 result=$?
 
 exit ${result}

--- a/Jenkinsfiles/build-bench.sh
+++ b/Jenkinsfiles/build-bench.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-vagrant ssh -c "set -e; cd /oscar/betrfs; mkdir -p build; cp qemu-utils/cmake-ft.sh build/; cd build; sed -i 's/DEBUG/RELEASE/g' cmake-ft.sh; ./cmake-ft.sh; cd ../filesystem; make"
+vagrant ssh -c "set -e; cd /oscar/betrfs; wget https://auku.cs.unc.edu/depot/linux-source-3.11.10-ftfs_20180618.00_all.deb; sudo dpkg -i linux-source-3.11.10-ftfs_20180618.00_all.deb; tar -xf /usr/src/linux-source-3.11.10-ftfs.tar.bz2; mv linux-source-3.11.10-ftfs linux-3.11.10; mkdir -p build; cp qemu-utils/cmake-ft.sh build/; cd build; sed -i 's/DEBUG/RELEASE/g' cmake-ft.sh; ./cmake-ft.sh; cd ../filesystem; make"
 result=$?
 
 exit ${result}

--- a/Jenkinsfiles/build-bench.sh
+++ b/Jenkinsfiles/build-bench.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-vagrant ssh -c "set -e; cd /oscar/betrfs; wget https://auku.cs.unc.edu/depot/linux-source-3.11.10-ftfs_20180618.00_all.deb; sudo dpkg -i linux-source-3.11.10-ftfs_20180618.00_all.deb; tar -xf /usr/src/linux-source-3.11.10-ftfs.tar.bz2; mv linux-source-3.11.10-ftfs linux-3.11.10; cd linux-3.11.10; cp ../qemu-utils/jenkins.config.3.11.10 .config; make oldconfig; mkdir -p build; cp qemu-utils/cmake-ft.sh build/; cd build; sed -i 's/DEBUG/RELEASE/g' cmake-ft.sh; ./cmake-ft.sh; cd ../filesystem; make"
+vagrant ssh -c "set -e; cd /oscar/betrfs; wget https://auku.cs.unc.edu/depot/linux-source-3.11.10-ftfs_20180618.00_all.deb; sudo dpkg -i linux-source-3.11.10-ftfs_20180618.00_all.deb; tar -xf /usr/src/linux-source-3.11.10-ftfs.tar.bz2; mv linux-source-3.11.10-ftfs linux-3.11.10; cd linux-3.11.10; cp ../qemu-utils/jenkins.config.3.11.10 .config; make oldconfig; cd ..; mkdir -p build; cp qemu-utils/cmake-ft.sh build/; cd build; sed -i 's/DEBUG/RELEASE/g' cmake-ft.sh; ./cmake-ft.sh; cd filesystem; make"
 result=$?
 
 exit ${result}

--- a/Jenkinsfiles/build.sh
+++ b/Jenkinsfiles/build.sh
@@ -4,7 +4,7 @@ touch console.out
 sudo chown libvirt-qemu console.out
 
 vagrant up > /dev/null
-vagrant ssh -c "set -e; cd /oscar/betrfs; wget https://auku.cs.unc.edu/depot/linux-source-3.11.10-ftfs_20180618.00_all.deb; sudo dpkg -i linux-source-3.11.10-ftfs_20180618.00_all.deb; tar -xf /usr/src/linux-source-3.11.10-ftfs.tar.bz2; mv linux-source-3.11.10-ftfs linux-3.11.10; mkdir -p build; cp qemu-utils/cmake-ft.sh build/; cd build; ./cmake-ft.sh; cd ../ftfs; make; rsync -vrlD /oscar/betrfs/ /vagrant/"
+vagrant ssh -c "set -e; cd /oscar/betrfs; wget https://auku.cs.unc.edu/depot/linux-source-3.11.10-ftfs_20180618.00_all.deb; sudo dpkg -i linux-source-3.11.10-ftfs_20180618.00_all.deb; tar -xf /usr/src/linux-source-3.11.10-ftfs.tar.bz2; mv linux-source-3.11.10-ftfs linux-3.11.10; mkdir -p build; cp qemu-utils/cmake-ft.sh build/; cd build; ./cmake-ft.sh; cd ../ftfs; make KDIR=3.11.10-ftfs; rsync -vrlD /oscar/betrfs/ /vagrant/"
 result=$?
 
 vagrant destroy -f

--- a/ftfs/.mkinclude
+++ b/ftfs/.mkinclude
@@ -1,3 +1,3 @@
-KDIR=$(shell uname -r)
+KDIR?=$(shell uname -r)
 #KDIR=3.11.10-ftfs
-MOD_KERN_SOURCE=$(PWD)/../linux-3.11.10
+MOD_KERN_SOURCE?=$(PWD)/../linux-3.11.10


### PR DESCRIPTION
After rolling the private repo to 4.19 kernel, we had a little bitrot on the public repo, which is still on 3.11.10.

Fix some minor issues to get 3.11.10 support working again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/betrfs/28)
<!-- Reviewable:end -->
